### PR TITLE
fix: fix wrong error message on field validation

### DIFF
--- a/src/components/auth-dialog.tsx
+++ b/src/components/auth-dialog.tsx
@@ -38,7 +38,7 @@ export function AuthDialog() {
     try {
       const result = await signIn?.create({
         identifier: email,
-        password: password,
+        password,
       })
       if (setActive) {
         await setActive({ session: result?.createdSessionId })

--- a/src/components/auth-dialog.tsx
+++ b/src/components/auth-dialog.tsx
@@ -38,12 +38,13 @@ export function AuthDialog() {
     try {
       const result = await signIn?.create({
         identifier: email,
-        password,
+        password: password,
       })
       if (setActive) {
         await setActive({ session: result?.createdSessionId })
       }
     } catch (error) {
+      console.log(error)
       setErrorMessage('Wrong email or password')
     }
   }
@@ -94,13 +95,19 @@ export function AuthDialog() {
                       <Input
                         type="email"
                         placeholder="Email Address"
+                        onChange={(e) => setEmail(e.target.value)}
                         required
                       />
                     </Clerk.Input>
                   </Clerk.Field>
                   <Clerk.Field name="password">
                     <Clerk.Input asChild>
-                      <Input type="password" placeholder="Password" required />
+                      <Input
+                        type="password"
+                        placeholder="Password"
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                      />
                     </Clerk.Input>
                   </Clerk.Field>
                   {errorMessage && (


### PR DESCRIPTION
- fixed a bug where the `Wrong email or password` message shows up even when there is correct login information.
- a bug was related to the status 422 which would throw errors even after the user correctly provided the login information.
- fixed a bug by adding `onChange` to each email and password field, so that both email and password are correctly recognized.

lmk if there's a better way to solve this bug!